### PR TITLE
Add Port definition to Controller Deployment

### DIFF
--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -118,6 +118,9 @@ spec:
         resources:
 {{ toYaml .Values.agones.controller.resources | indent 10 }}
 {{- end }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.agones.controller.http.port }}
         volumeMounts:
         - name: certs
           mountPath: /home/agones/certs


### PR DESCRIPTION
Prometheus pod scrape configuration wouldn't work because the pod definition for the controller didn't contain any port definitions. 

Just adding the port that the controller is already listening on to the Deployment spec has fixed the issue.